### PR TITLE
fix: Fix download url for macos users

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -55,6 +55,10 @@ get_arch() {
       ;;
   esac
 
+  if [ "$(get_platform)" == "Darwin" ]; then
+    arch='all'
+  fi
+
   echo ${arch}
 }
 


### PR DESCRIPTION
Starting with goreleaser v0.182.0 (https://github.com/goreleaser/goreleaser/pull/2572), universal binaries were created for macOS, which breaks the plugin for macOS users with:

```
$ asdf install goreleaser 0.182.1
Downloading GoReleaser from https://github.com/goreleaser/goreleaser/releases/download/v0.182.1/goreleaser_Darwin_x86_64.tar.gz
tar: Error opening archive: Unrecognized archive format
```

The download url is now https://github.com/goreleaser/goreleaser/releases/download/v0.182.1/goreleaser_Darwin_all.tar.gz. I have made this fix in the install script here, and tested it on my fork.

```
$ asdf plugin test goreleaser git@github.com:gracedo/asdf-goreleaser.git
Downloading GoReleaser from https://github.com/goreleaser/goreleaser/releases/download/v0.182.1/goreleaser_Darwin_all.tar.gz
```