### PR TITLE
Download correct tarball for Linux on M1 mac

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -50,6 +50,9 @@ get_arch() {
     x86_64)
       arch='x86_64'
       ;;
+    aarch64)
+      arch='arm64'
+      ;;
     i386)
       arch='i386'
       ;;


### PR DESCRIPTION
Fixes #2 

I've tested as part of an `asdf` container:

```
# Installing goreleaser version
Downloading GoReleaser from https://github.com/goreleaser/goreleaser/releases/download/v1.10.3/goreleaser_Linux_arm64.tar.gz
```

this is working as expected